### PR TITLE
Support extra semicolons in protobuf file

### DIFF
--- a/parse.js
+++ b/parse.js
@@ -104,6 +104,10 @@ var onmessagebody = function (tokens) {
         body.oneof.push(ononeof(tokens))
         break
 
+      case ';':
+        tokens.shift()
+        break
+
       default:
         throw new Error('Unexpected token in message: ' + tokens[0])
     }


### PR DESCRIPTION
Support extra semicolons in protobuf definition file. This allows
protobuf-schema to parse the google rtb protobuf file. [1]

[1] https://developers.google.com/ad-exchange/rtb/downloads/realtime-bidding-proto.txt